### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ Nuxt module to load SVG files as Vue components, using SVGO for optimization.
 Install and add nuxt-svgo-loader to your nuxt.config.
 
 ```bash
-# Whichever matches your package manager
-pnpm add -D nuxt-svgo-loader
-npm install -D nuxt-svgo-loader
-yarn add -D nuxt-svgo-loader
+npx nuxi@latest module add nuxt-svgo-loader
 ```
 
 ```ts


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
