### PR TITLE
fix: image overflow in preview box

### DIFF
--- a/client/components/SvgDetails.vue
+++ b/client/components/SvgDetails.vue
@@ -40,7 +40,9 @@ function onCopy(mode?: LoaderMode) {
       <div class="h-px w-full bg-gray/15" />
     </div>
 
-    <SvgPreview class="max-h-80 min-h-20 min-w-20 w-auto" :src="`/__nuxt-svgo-loader/svg/${selected.path}`" :alt="selected.name" />
+    <div class="flex items-center justify-center">
+      <SvgPreview class="max-h-80 min-h-20 min-w-20 w-auto" :src="`/__nuxt-svgo-loader/svg/${selected.path}`" :alt="selected.name" />
+    </div>
 
     <div class="flex gap-2 items-center -mb-2 opacity-50">
       <div class="h-px w-full bg-gray/15" />

--- a/client/components/SvgPreview.vue
+++ b/client/components/SvgPreview.vue
@@ -7,6 +7,6 @@ defineProps<{
 
 <template>
   <div class="flex items-center justify-center rounded border border-gray/5 p-1 object-cover overflow-hidden bg-[#9CA3AF]/5">
-    <img :src="src" alt="alt">
+    <img class="max-h-full" :src="src" alt="alt">
   </div>
 </template>


### PR DESCRIPTION
I encountered an issue where [this Icon](https://icon-sets.iconify.design/fa/facebook/) from Iconify , overflowed the preview box:

<img width="818" alt="image" src="https://github.com/user-attachments/assets/537d18a0-4613-4404-8495-01dae3cff362">

Under the following conditions, I was able to reproduce this issue:

1. The SVG does not have predefined width and height attributes.
2. The SVG’s viewBox parameters for width and height exceed the preview box limit (110px).

I added constraints to the `<img>` tag to ensure that the image does not exceed the preview boundaries. This fix ensures that the icon displays correctly in both the list view and the preview page.

![image](https://github.com/user-attachments/assets/e84fc9e4-dc6b-4e81-b8a9-be4f32a8cc26)


