### PR TITLE
fix: limit processing to template and script blocks only

### DIFF
--- a/src/plugins/svgo-icon-transform.ts
+++ b/src/plugins/svgo-icon-transform.ts
@@ -44,7 +44,7 @@ export function SvgoIconTransform(options: LoaderOptions) {
           if (include.some(pattern => pattern.test(id))) {
             return true
           }
-          return isVue(id)
+          return isVue(id, { type: ['template', 'script'] })
         },
 
         transform: {
@@ -156,7 +156,7 @@ export function SvgoIconTransform(options: LoaderOptions) {
           if (include.some(pattern => pattern.test(id))) {
             return true
           }
-          return isVue(id)
+          return isVue(id, { type: ['template', 'script'] })
         },
 
         transform: {


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #7 

### 📚 Description|

Ensure that only the `<template>` and `<script>` blocks are processed.